### PR TITLE
fixed mention listener

### DIFF
--- a/bot/cogs/events.py
+++ b/bot/cogs/events.py
@@ -16,7 +16,7 @@ class Events(commands.Cog):
     @commands.Cog.listener()
     async def on_message(self, message):
 
-        if message.author.bot == False and message.content in ("<@!769137475942613023>" "<@769137475942613023>"):
+        if not message.author.bot and self.bot.user.mentioned_in(message):
             await message.channel.send("Hey! My prefix's are: `resolute `, `r.` ")
 
     @commands.Cog.listener()


### PR DESCRIPTION
You forgot a comma between the 2 mention strings so the 2 strings are implicitly concatenated to become one large string and not a tuple as there is no comma
 so it is instead checking if content is in string which is likely to be true if the content consists of any character that exists within that string.

To fix you could've added a comma alternatively use `mentioned_in`